### PR TITLE
docs: add package-level READMEs for core, react, and angular

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,0 +1,157 @@
+# @markit/angular
+
+Angular bindings for the [@markit/core](https://github.com/saurabhiam/markit/tree/main/packages/core) text highlighting engine. Provides a standalone `MarkitHighlightDirective` and an injectable `MarkitService`.
+
+## Install
+
+```bash
+npm install @markit/angular @markit/core
+# or
+bun add @markit/angular @markit/core
+```
+
+**Peer dependencies:** Angular 17, 18, or 19
+
+## Quick Start
+
+### Directive
+
+Import the standalone directive in your component:
+
+```typescript
+import { Component } from '@angular/core';
+import { MarkitHighlightDirective } from '@markit/angular';
+
+@Component({
+  selector: 'app-search',
+  standalone: true,
+  imports: [MarkitHighlightDirective],
+  template: `
+    <input [(ngModel)]="searchTerm" placeholder="Search..." />
+
+    <div [markitHighlight]="searchTerm" [markitOptions]="highlightOptions">
+      <p>This content will be searched and highlighted.</p>
+      <app-child></app-child>
+      <!-- bindings preserved -->
+    </div>
+  `,
+})
+export class SearchComponent {
+  searchTerm = '';
+  highlightOptions = { caseSensitive: false, accuracy: 'partially' as const };
+}
+```
+
+### Service
+
+For programmatic control, inject `MarkitService`:
+
+```typescript
+import { Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
+import { MarkitService } from '@markit/angular';
+import type { MarkitInstance } from '@markit/core';
+
+@Component({
+  selector: 'app-editor',
+  template: `<div #content>Searchable content here.</div>`,
+})
+export class EditorComponent implements OnDestroy {
+  @ViewChild('content', { static: true }) contentRef!: ElementRef<HTMLElement>;
+
+  private instance: MarkitInstance | null = null;
+
+  constructor(private markitService: MarkitService) {}
+
+  search(term: string) {
+    this.instance?.destroy();
+    this.instance = this.markitService.create(this.contentRef.nativeElement);
+    this.markitService.highlight(this.instance, term, {
+      renderer: 'dom',
+      caseSensitive: false,
+    });
+  }
+
+  clear() {
+    this.markitService.clear(this.instance!);
+  }
+
+  ngOnDestroy() {
+    this.instance?.destroy();
+  }
+}
+```
+
+## API
+
+### `MarkitHighlightDirective`
+
+Standalone attribute directive. Apply to any element whose text content you want to highlight.
+
+| Input             | Type                     | Description                                           |
+| ----------------- | ------------------------ | ----------------------------------------------------- |
+| `markitHighlight` | `string \| string[]`     | Search term(s) to highlight                           |
+| `markitOptions`   | `Partial<MarkitOptions>` | All `@markit/core` options (renderer, accuracy, etc.) |
+| `markitPlugins`   | `MarkitPlugin[]`         | Plugins to register                                   |
+
+### `MarkitService`
+
+Injectable service (`providedIn: 'root'`). All operations run outside `NgZone`.
+
+| Method                                        | Description                |
+| --------------------------------------------- | -------------------------- |
+| `create(element, plugins?)`                   | Create a `MarkitInstance`  |
+| `highlight(instance, term, options?)`         | Apply keyword highlighting |
+| `highlightRegExp(instance, regexp, options?)` | Apply regex highlighting   |
+| `clear(instance)`                             | Remove all highlights      |
+
+## NgZone Safety
+
+Both the directive and service run highlighting **outside NgZone** to avoid triggering unnecessary change detection cycles. This is especially important for DOM-mutating renderers.
+
+Callbacks (`done`, `noMatch`) automatically **re-enter the zone**, so updating component state from callbacks works correctly:
+
+```typescript
+highlightOptions = {
+  done: (count: number) => {
+    this.matchCount = count; // safe — re-enters NgZone automatically
+  },
+};
+```
+
+## Change Detection Compatibility
+
+| Strategy     | Works? | Notes                                                      |
+| ------------ | ------ | ---------------------------------------------------------- |
+| **Default**  | Yes    | No unnecessary cycles triggered                            |
+| **OnPush**   | Yes    | Changes fire via `@Input` bindings through `OnChanges`     |
+| **Signals**  | Yes    | Bind a signal in the template; directive reacts via inputs |
+| **Zoneless** | Yes    | Operations already run outside zone                        |
+
+## Preserving Bindings
+
+Unlike `innerHTML`-based approaches, MarkIt never replaces DOM nodes. The CSS Highlight API (default) creates **zero DOM mutations**. Even the DOM wrapping renderer only splits text nodes and wraps them — it never destroys component instances, event listeners, or form control state.
+
+## Batched Rendering
+
+For large content areas, enable batched rendering:
+
+```html
+<div [markitHighlight]="searchTerm" [markitOptions]="{ batchSize: 500, done: onHighlightDone }">
+  <!-- large content -->
+</div>
+```
+
+## CSS Highlight API Styling
+
+When using the default `auto` renderer on supported browsers, add this to your global styles:
+
+```css
+::highlight(markit-highlight) {
+  background-color: #fef08a;
+  color: inherit;
+}
+```
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,138 @@
+# @markit/core
+
+Framework-agnostic, high-performance text highlighting engine. Serves as the foundation for `@markit/react` and `@markit/angular`.
+
+## Install
+
+```bash
+npm install @markit/core
+# or
+bun add @markit/core
+```
+
+## Quick Start
+
+```ts
+import { markit } from '@markit/core';
+
+const instance = markit(document.querySelector('#content'));
+
+// Keyword highlighting
+instance.mark('hello');
+
+// Multiple keywords
+instance.mark(['hello', 'world']);
+
+// Regex
+instance.markRegExp(/\b\w{6,}\b/g);
+
+// Clear
+instance.unmark();
+
+// Cleanup
+instance.destroy();
+```
+
+## Rendering Engines
+
+The library ships with three rendering strategies, selectable via the `renderer` option:
+
+| Engine         | Option            | DOM Mutations | Browser Support   |
+| -------------- | ----------------- | ------------- | ----------------- |
+| CSS Highlight  | `'highlight-api'` | None          | Chrome 105+, Edge |
+| DOM Wrapping   | `'dom'`           | Yes           | All browsers      |
+| Overlay        | `'overlay'`       | Minimal       | All browsers      |
+| Auto (default) | `'auto'`          | Varies        | Feature-detected  |
+
+`auto` prefers the CSS Custom Highlight API when available, falling back to DOM wrapping.
+
+## Options
+
+```ts
+instance.mark('search term', {
+  renderer: 'auto', // 'highlight-api' | 'dom' | 'overlay' | 'auto'
+  caseSensitive: false,
+  ignoreDiacritics: false,
+  acrossElements: false,
+  separateWordSearch: false,
+  accuracy: 'partially', // 'partially' | 'exactly' | 'startsWith' | 'complementary'
+  wildcards: 'disabled', // 'disabled' | 'enabled' | 'withSpaces'
+  ignoreJoiners: false,
+  ignorePunctuation: [],
+  synonyms: {},
+  exclude: [],
+  element: 'mark',
+  className: 'markit-match',
+  highlightName: 'markit-highlight',
+  batchSize: 0, // > 0 enables incremental rendering
+  debounce: 0,
+  debug: false,
+
+  // Callbacks
+  each: (element, info) => {},
+  done: (totalMatches) => {},
+  noMatch: (term) => {},
+  filter: (textNode, term, matchIndex, totalMatches) => true,
+});
+```
+
+## Plugins
+
+```ts
+import { markit, type MarkitPlugin } from '@markit/core';
+
+const logger: MarkitPlugin = {
+  name: 'logger',
+  afterMatch(matches) {
+    console.log(`Found ${matches.length} matches`);
+    return matches;
+  },
+};
+
+const instance = markit(element, [logger]);
+```
+
+## CSS Highlight API Styling
+
+When using the `highlight-api` or `auto` renderer, style matches with the `::highlight()` pseudo-element:
+
+```css
+::highlight(markit-highlight) {
+  background-color: #fef08a;
+  color: inherit;
+}
+```
+
+## Batched Rendering
+
+For very large DOM trees (50K+ nodes), enable batched rendering to keep the UI responsive:
+
+```ts
+instance.mark('term', {
+  batchSize: 500,
+  done: (count) => console.log(`${count} matches rendered`),
+});
+```
+
+Rendering is split across `requestIdleCallback` / `requestAnimationFrame` frames. New `mark()` calls automatically cancel any in-progress batch.
+
+## API Reference
+
+### `markit(element, plugins?)`
+
+Creates and returns a `MarkitInstance`.
+
+### `MarkitInstance`
+
+| Method                         | Description                    |
+| ------------------------------ | ------------------------------ |
+| `mark(term, options?)`         | Highlight keyword(s)           |
+| `markRegExp(regexp, options?)` | Highlight regex matches        |
+| `markRanges(ranges, options?)` | Highlight specific char ranges |
+| `unmark(options?)`             | Remove all highlights          |
+| `getMatches()`                 | Get current `MatchResult[]`    |
+| `destroy()`                    | Clean up and free resources    |
+
+## License
+
+MIT

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,142 @@
+# @markit/react
+
+React bindings for the [@markit/core](https://github.com/saurabhiam/markit/tree/main/packages/core) text highlighting engine. Provides a `useHighlight` hook and a declarative `Highlighter` component.
+
+## Install
+
+```bash
+npm install @markit/react @markit/core
+# or
+bun add @markit/react @markit/core
+```
+
+**Peer dependencies:** React 18+ or 19+
+
+## Quick Start
+
+### Hook
+
+```tsx
+import { useHighlight } from '@markit/react';
+
+function SearchResults({ query }: { query: string }) {
+  const ref = useHighlight(query, { caseSensitive: false });
+
+  return (
+    <div ref={ref}>
+      <p>Content to search and highlight.</p>
+    </div>
+  );
+}
+```
+
+### Component
+
+```tsx
+import { Highlighter } from '@markit/react';
+
+function App() {
+  return (
+    <Highlighter term="react" accuracy="exactly">
+      <article>
+        <p>React is a JavaScript library for building user interfaces.</p>
+      </article>
+    </Highlighter>
+  );
+}
+```
+
+## API
+
+### `useHighlight(term, options?)`
+
+Returns a `ref` to attach to the container element.
+
+```ts
+const ref = useHighlight<HTMLDivElement>(term, {
+  // All @markit/core options, plus:
+  plugins: [], // MarkitPlugin[]
+  timing: 'effect', // 'effect' (default) | 'layout'
+});
+```
+
+| Option    | Type                   | Description                                                                                            |
+| --------- | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `timing`  | `'effect' \| 'layout'` | `'effect'` runs after paint (SSR-safe). `'layout'` runs before paint (avoids flash with DOM renderer). |
+| `plugins` | `MarkitPlugin[]`       | Plugins to register with the core instance.                                                            |
+
+All other options are passed through to `@markit/core`'s `mark()` method.
+
+### `Highlighter`
+
+Declarative component that wraps children and highlights matching text.
+
+```tsx
+<Highlighter
+  term="search" // string | string[]
+  as="div" // Container element tag (default: 'div')
+  className="my-class" // Container CSS class
+  style={{ padding: 16 }} // Container inline styles
+  caseSensitive={false} // Any @markit/core option
+  renderer="auto"
+/>
+```
+
+## Safety
+
+The bindings are designed to be safe across React's rendering model:
+
+| Concern                   | How it's handled                                          |
+| ------------------------- | --------------------------------------------------------- |
+| **StrictMode**            | Cleanup runs before re-invocation; `unmark` is idempotent |
+| **Concurrent rendering**  | Effects only run on committed renders                     |
+| **Next.js SSR/hydration** | `useEffect` doesn't run on the server or during hydration |
+| **Re-renders**            | Options are shallow-compared; no work if nothing changed  |
+| **Unmount**               | `destroy()` is called in the effect cleanup               |
+
+## Next.js Usage
+
+The `Highlighter` component includes a `'use client'` directive. Use it inside Client Components:
+
+```tsx
+// app/search/results.tsx
+'use client';
+
+import { Highlighter } from '@markit/react';
+
+export function Results({ query, html }: { query: string; html: string }) {
+  return (
+    <Highlighter term={query} renderer="auto">
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </Highlighter>
+  );
+}
+```
+
+Server Components can render the content; the `Highlighter` applies highlights client-side after hydration.
+
+## Batched Rendering
+
+For large content areas, enable batched rendering to keep the UI responsive:
+
+```tsx
+const ref = useHighlight(query, {
+  batchSize: 500,
+  done: (count) => setMatchCount(count),
+});
+```
+
+## CSS Highlight API Styling
+
+When using the default `auto` renderer on supported browsers, add this CSS:
+
+```css
+::highlight(markit-highlight) {
+  background-color: #fef08a;
+  color: inherit;
+}
+```
+
+## License
+
+MIT


### PR DESCRIPTION
Each README covers install, API reference, usage examples, and package-specific guidance (NgZone safety, SSR/hydration, rendering engines) so npm package pages are self-contained.