### PR TITLE
chore: update permissions in prepare-release workflow to allow pull request access

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,6 +19,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   prepare:


### PR DESCRIPTION
- Added 'pull-requests: write' permission to the prepare-release workflow to enable better management of pull requests during the release process.