### PR TITLE
Enhance DomRenderer to merge text nodes on clear() and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ High-performance text highlighting for the modern web. A production-grade altern
 
 - **Fast** — Designed to rival Chrome's native Find in Page. Uses `TreeWalker` for O(n) traversal, binary search for match resolution, and zero-layout-cost rendering via the CSS Custom Highlight API.
 - **Framework-safe** — Never uses `innerHTML`. Preserves Angular bindings, React reconciliation, event listeners, and component trees.
-- **Three rendering engines** — CSS Highlight API (zero DOM mutations), DOM wrapping (Range API + text node splitting), and overlay positioning. Auto-detects the best engine for your browser.
+- **Three rendering engines** — CSS Highlight API (zero DOM mutations), DOM wrapping (text node splitting, preserves original node for bindings), and overlay positioning. Auto-detects the best engine for your browser.
 - **Batched rendering** — For very large DOMs (50K+ nodes), split rendering across animation frames with `batchSize` to keep the UI responsive.
 - **Full-featured** — Regex, multiple keywords, case sensitivity, diacritics, synonyms, wildcards, accuracy modes, exclude selectors, across-elements matching, and more.
 - **Tiny & tree-shakeable** — ESM and CJS builds with `sideEffects: false`.

--- a/apps/docs/guide/angular.md
+++ b/apps/docs/guide/angular.md
@@ -132,7 +132,7 @@ All highlighting runs **outside NgZone** via `NgZone.runOutsideAngular()`. This 
 
 ### No innerHTML
 
-MarkIt never uses `innerHTML`. The DOM renderer splits text nodes using the Range API and wraps matches with `Range.surroundContents()`. This preserves:
+MarkIt never uses `innerHTML`. The DOM renderer splits text nodes and wraps matches in `<mark>` (or a configured element), **keeping the original text node in place** so Angular’s bindings continue to update the same node—including when the match is at the start of the text. This preserves:
 
 - Angular's internal `LView` references
 - Template bindings (`[value]`, `(click)`, `*ngIf`)

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -102,7 +102,7 @@ MarkIt uses a **dual-engine architecture**:
 
 1. **CSS Custom Highlight API** (default) — Creates `Range` objects and registers them with the browser's highlight registry. Styled via `::highlight()`. Zero DOM mutations. Supported in Chrome 105+, Edge 105+, Safari 17.2+, Firefox 140+; unsupported browsers fall back to the DOM renderer with `renderer: 'auto'`.
 
-2. **DOM Range Renderer** (fallback) — Splits text nodes and wraps matches in `<mark>` elements using the Range API. Never uses `innerHTML`.
+2. **DOM renderer** (fallback) — Splits text nodes and wraps matches in `<mark>` elements, keeping the original text node in place so framework bindings (e.g. Angular, React) keep updating. Never uses `innerHTML`.
 
 The engine is selected automatically via feature detection, or you can force one:
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -136,7 +136,7 @@ highlightOptions = {
 
 ## Preserving Bindings
 
-Unlike `innerHTML`-based approaches, MarkIt never replaces DOM nodes. The CSS Highlight API (default) creates **zero DOM mutations**. Even the DOM wrapping renderer only splits text nodes and wraps them — it never destroys component instances, event listeners, or form control state.
+Unlike `innerHTML`-based approaches, MarkIt never replaces DOM nodes. The CSS Highlight API (default) creates **zero DOM mutations**. The DOM wrapping renderer splits text nodes and wraps matches while **keeping the original text node in place**, so framework bindings (e.g. `{{ value }}`) continue to update correctly and it never destroys component instances, event listeners, or form control state.
 
 ## Batched Rendering
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,7 +44,7 @@ The library ships with three rendering strategies, selectable via the `renderer`
 | Overlay        | `'overlay'`       | Minimal       | All browsers                                       |
 | Auto (default) | `'auto'`          | Varies        | Feature-detected                                   |
 
-`auto` prefers the CSS Custom Highlight API when available, falling back to DOM wrapping.
+`auto` prefers the CSS Custom Highlight API when available, falling back to DOM wrapping. The DOM renderer never removes the original text node—only updates its `textContent` and inserts wrappers—so framework bindings (Angular, React, etc.) keep updating correctly, including when the match is at the start of the text.
 
 ## Multiple instances
 

--- a/packages/core/__tests__/dom-renderer.test.ts
+++ b/packages/core/__tests__/dom-renderer.test.ts
@@ -92,6 +92,25 @@ describe('DomRenderer', () => {
     expect(container.querySelector('p')!.childNodes).toHaveLength(1);
   });
 
+  it('start-of-node match: keeps original text node in DOM and clear() merges back', () => {
+    const resolved = highlightAndResolve('<p>Hello world</p>', 'Hello');
+    renderer.render(resolved, { element: 'mark', className: 'markit-match' } as MarkitOptions);
+
+    const p = container.querySelector('p')!;
+    const mark = p.querySelector('mark')!;
+    expect(mark.textContent).toBe('Hello');
+    // Wrapper is before the preserved text node (remainder " world")
+    expect(mark.nextSibling?.nodeType).toBe(Node.TEXT_NODE);
+    expect((mark.nextSibling as Text).textContent).toBe(' world');
+    expect(p.textContent).toBe('Hello world');
+
+    renderer.clear();
+
+    expect(p.querySelectorAll('mark')).toHaveLength(0);
+    expect(p.textContent).toBe('Hello world');
+    expect(p.childNodes).toHaveLength(1);
+  });
+
   it('does not use innerHTML', () => {
     const originalInnerHTML = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML');
 

--- a/packages/core/src/engines/dom-renderer.ts
+++ b/packages/core/src/engines/dom-renderer.ts
@@ -1,6 +1,8 @@
 import type { RendererInterface, ResolvedMatch, MarkitOptions } from '../types.js';
 
 const DATA_ATTR = 'data-markit-id';
+/** Set only on start-of-node wrappers so clear() merges into the preserved node (avoids doing the merge for every wrapper). */
+const MERGE_NEXT_ATTR = 'data-markit-merge-next';
 let idCounter = 0;
 
 function generateId(): string {
@@ -9,15 +11,18 @@ function generateId(): string {
 
 /**
  * DOM-based renderer that wraps matches by splitting text nodes
- * and inserting wrapper elements using the Range API.
+ * and inserting wrapper elements.
  *
- * NEVER uses innerHTML. Only operates on Text nodes via:
- *   1. Range.surroundContents() for simple cases
- *   2. Manual text node splitting for cross-node matches
+ * NEVER uses innerHTML. Only operates on Text nodes by splitting
+ * into [before, match, after] and inserting a wrapper around the
+ * match. The original text node is never removed—only its
+ * textContent is updated—so framework bindings (Angular, React, etc.)
+ * continue to update the same node.
  *
- * This preserves the parent element structure, Angular bindings,
- * React reconciliation targets, and all event listeners attached
- * to Element nodes.
+ * Multiple matches in the same node are processed in reverse document
+ * order. Overlapping start-of-node matches (e.g. "H" and "Hello") on the
+ * same node: the first wrap wins; later segments are skipped if the node
+ * was already shortened (stale-segment guard).
  */
 export class DomRenderer implements RendererInterface {
   private wrapperElements: Element[] = [];
@@ -64,25 +69,40 @@ export class DomRenderer implements RendererInterface {
   }
 
   clear(): void {
-    // Unwrap all wrapper elements: replace with their text content,
-    // then normalize parent to merge adjacent text nodes.
-    const parents = new Set<Node>();
+    // Unwrap all wrapper elements: move children out, remove wrapper.
+    const parentsThatNeedNormalize = new Set<Node>();
 
     for (const wrapper of this.wrapperElements) {
       const parent = wrapper.parentNode;
       if (!parent) continue;
 
-      parents.add(parent);
-
-      // Replace wrapper with its child text nodes
       while (wrapper.firstChild) {
         parent.insertBefore(wrapper.firstChild, wrapper);
       }
+
+      let merged = false;
+      if (wrapper.hasAttribute(MERGE_NEXT_ATTR)) {
+        const matchTextNode = wrapper.previousSibling;
+        const preservedNode = wrapper.nextSibling;
+        if (
+          matchTextNode?.nodeType === Node.TEXT_NODE &&
+          preservedNode?.nodeType === Node.TEXT_NODE
+        ) {
+          const text = (matchTextNode as Text).data;
+          (preservedNode as Text).insertData(0, text);
+          parent.removeChild(matchTextNode);
+          merged = true;
+        }
+      }
+      if (!merged) {
+        parentsThatNeedNormalize.add(parent);
+      }
+
       parent.removeChild(wrapper);
     }
 
     // Merge adjacent text nodes that were split during highlighting
-    for (const parent of parents) {
+    for (const parent of parentsThatNeedNormalize) {
       parent.normalize();
     }
 
@@ -94,8 +114,11 @@ export class DomRenderer implements RendererInterface {
   }
 
   /**
-   * Wrap a range within a single text node. Uses Range API to split
-   * the text node at the boundaries and surround the middle part.
+   * Wrap a range within a single text node. Single strategy: split into
+   * [before, match, after], wrap the match, and never remove the original
+   * text node—only update its textContent. This keeps framework-owned
+   * nodes in the DOM whether the match is at the start or in the middle.
+   * Returns null if the segment is stale (node was already shortened by a prior wrap).
    */
   private wrapTextRange(
     textNode: Text,
@@ -105,60 +128,34 @@ export class DomRenderer implements RendererInterface {
     className: string,
   ): Element | null {
     if (startOffset >= endOffset) return null;
-    if (!textNode.parentNode) return null;
-
-    const range = document.createRange();
-    range.setStart(textNode, startOffset);
-    range.setEnd(textNode, endOffset);
-
-    const wrapper = document.createElement(tag);
-    wrapper.className = className;
-    wrapper.setAttribute(DATA_ATTR, generateId());
-
-    try {
-      range.surroundContents(wrapper);
-    } catch {
-      // surroundContents fails if the range crosses element boundaries.
-      // For single-segment matches within one text node, this won't happen.
-      // If it does, fall back to manual splitting.
-      return this.manualWrap(textNode, startOffset, endOffset, wrapper);
-    }
-
-    return wrapper;
-  }
-
-  /**
-   * Manual text node split + wrap fallback.
-   * Splits the text node into [before, match, after] and wraps the match.
-   */
-  private manualWrap(
-    textNode: Text,
-    startOffset: number,
-    endOffset: number,
-    wrapper: Element,
-  ): Element | null {
     const parent = textNode.parentNode;
     if (!parent) return null;
 
     const fullText = textNode.textContent ?? '';
+    // If the segment is stale (node was already shortened by a prior wrap), return null.
+    if (fullText.length < endOffset) return null;
+
     const beforeText = fullText.slice(0, startOffset);
     const matchText = fullText.slice(startOffset, endOffset);
     const afterText = fullText.slice(endOffset);
 
-    const matchTextNode = document.createTextNode(matchText);
-    wrapper.appendChild(matchTextNode);
-
-    if (afterText) {
-      const afterNode = document.createTextNode(afterText);
-      parent.insertBefore(afterNode, textNode.nextSibling);
-    }
-
-    parent.insertBefore(wrapper, textNode.nextSibling);
+    const wrapper = document.createElement(tag);
+    wrapper.className = className;
+    wrapper.setAttribute(DATA_ATTR, generateId());
+    wrapper.appendChild(document.createTextNode(matchText));
 
     if (beforeText) {
+      // Match in the middle (or end): keep node with "before", insert wrapper, then "after".
       textNode.textContent = beforeText;
+      parent.insertBefore(wrapper, textNode.nextSibling);
+      if (afterText) {
+        parent.insertBefore(document.createTextNode(afterText), wrapper.nextSibling);
+      }
     } else {
-      parent.removeChild(textNode);
+      // Match at the start: insert wrapper before node, keep node with "after".
+      wrapper.setAttribute(MERGE_NEXT_ATTR, '1');
+      parent.insertBefore(wrapper, textNode);
+      textNode.textContent = afterText;
     }
 
     return wrapper;


### PR DESCRIPTION
- Added functionality to preserve original text nodes during highlighting and ensure they are merged back correctly when clear() is called.
- Introduced a new attribute to manage merging behavior for start-of-node matches, improving text node handling and maintaining DOM structure.
- Updated tests to verify the new merging behavior and ensure correct rendering after clearing highlights.