### PR TITLE
refactor: improve clear() method in DomRenderer to handle text node unwrapping

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -19,9 +19,7 @@ import DefaultTheme from 'vitepress/theme';
             >.
             <br />
             <span class="footer-india">
-              <a href="https://madewithloveinindia.org" target="_blank" rel="noopener"
-                >Made with <span aria-label="Love" class="footer-heart">&hearts;</span> in India</a
-              >
+              Made with <span aria-label="Love" class="footer-heart">&hearts;</span> in India
             </span>
           </p>
         </div>
@@ -62,14 +60,7 @@ import DefaultTheme from 'vitepress/theme';
 
 .footer-india {
   margin-left: 0.5rem;
-}
-
-.footer-india a {
-  color: var(--vp-c-text-2) !important;
-}
-
-.footer-india a:hover {
-  color: var(--vp-c-text-1) !important;
+  color: var(--vp-c-text-2);
 }
 
 .footer-heart {

--- a/apps/docs/guide/core-api.md
+++ b/apps/docs/guide/core-api.md
@@ -94,6 +94,8 @@ instance.destroy();
 | `ignoreJoiners`      | `boolean`                                                     | `false`              | Ignore zero-width characters                                   |
 | `ignorePunctuation`  | `string[]`                                                    | —                    | Punctuation characters to ignore                               |
 | `exclude`            | `string[]`                                                    | —                    | CSS selectors to exclude from search                           |
+| `iframes`            | `boolean`                                                     | `false`              | Enable iframe traversal (same-origin only)                     |
+| `iframesTimeout`     | `number`                                                      | `5000`               | Timeout in ms for iframe loading                               |
 | `debounce`           | `number`                                                      | `0`                  | Debounce delay in ms for live search                           |
 | `batchSize`          | `number`                                                      | `0`                  | Render matches in async batches of this size (0 = synchronous) |
 | `debug`              | `boolean`                                                     | `false`              | Log timing info to console                                     |
@@ -108,6 +110,10 @@ With the `highlight-api` or `auto` renderer, multiple MarkIt instances share one
 
 ::: info Browser support for Highlight API
 The `highlight-api` (and `auto`) renderer uses the CSS Custom Highlight API. It is supported in **Chrome 105+**, **Edge 105+**, **Safari 17.2+**, and **Firefox 140+**. In older or unsupported environments, use `renderer: 'dom'` or rely on `auto` to fall back to DOM wrapping.
+:::
+
+::: info DOM renderer and framework bindings
+The DOM renderer never removes the framework-owned text node. For matches in the middle or end of a node, it only updates that node's `textContent` to the "before" part and inserts the wrapper and "after" text. For matches at the **start** of a node, it inserts the wrapper before the node and keeps the node in place with only the "after" text. On `unmark()`/`clear()`, it merges wrapped text back into that same node. So Angular, React, and other frameworks keep updating the same DOM node and dynamic content (e.g. with `markitContentKey` or `contentKey`) stays correct.
 :::
 
 ## Callbacks

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -136,7 +136,7 @@ highlightOptions = {
 
 ## Preserving Bindings
 
-Unlike `innerHTML`-based approaches, MarkIt never replaces DOM nodes. The CSS Highlight API (default) creates **zero DOM mutations**. The DOM wrapping renderer splits text nodes and wraps matches while **keeping the original text node in place**, so framework bindings (e.g. `{{ value }}`) continue to update correctly and it never destroys component instances, event listeners, or form control state.
+Unlike `innerHTML`-based approaches, MarkIt never replaces DOM nodes. The CSS Highlight API (default) creates **zero DOM mutations**. The DOM wrapping renderer splits text nodes and wraps matches while **keeping the original text node in place**—including when the match is at the start of the text—so framework bindings (e.g. `{{ value }}`) continue to update correctly and it never destroys component instances, event listeners, or form control state.
 
 ## Batched Rendering
 

--- a/packages/core/src/engines/dom-renderer.ts
+++ b/packages/core/src/engines/dom-renderer.ts
@@ -76,11 +76,7 @@ export class DomRenderer implements RendererInterface {
       if (!parent) continue;
 
       // wrapTextRange creates a single text node, which we unwrap here.
-      const matchTextNode = wrapper.firstChild;
-      if (!matchTextNode) {
-        parent.removeChild(wrapper);
-        continue;
-      }
+      const matchTextNode = wrapper.firstChild!;
       parent.insertBefore(matchTextNode, wrapper);
 
       let merged = false;

--- a/packages/core/src/engines/dom-renderer.ts
+++ b/packages/core/src/engines/dom-renderer.ts
@@ -69,20 +69,22 @@ export class DomRenderer implements RendererInterface {
   }
 
   clear(): void {
-    // Unwrap all wrapper elements: move children out, remove wrapper.
     const parentsThatNeedNormalize = new Set<Node>();
 
     for (const wrapper of this.wrapperElements) {
       const parent = wrapper.parentNode;
       if (!parent) continue;
 
-      while (wrapper.firstChild) {
-        parent.insertBefore(wrapper.firstChild, wrapper);
+      // wrapTextRange creates a single text node, which we unwrap here.
+      const matchTextNode = wrapper.firstChild;
+      if (!matchTextNode) {
+        parent.removeChild(wrapper);
+        continue;
       }
+      parent.insertBefore(matchTextNode, wrapper);
 
       let merged = false;
       if (wrapper.hasAttribute(MERGE_NEXT_ATTR)) {
-        const matchTextNode = wrapper.previousSibling;
         const preservedNode = wrapper.nextSibling;
         if (
           matchTextNode?.nodeType === Node.TEXT_NODE &&


### PR DESCRIPTION
- Updated the clear() method to unwrap text nodes from wrapper elements more efficiently.
- Ensured that text nodes are preserved and correctly reinserted into the DOM structure.
- Enhanced handling of wrapper elements to maintain DOM integrity during the clear operation.